### PR TITLE
Shorten LED clock channel labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -529,23 +529,17 @@
     function getSystemChannel() {
       const d = new Date();
 
-      const dateFmt = d.toLocaleDateString('es-AR', {
-        timeZone: 'America/Argentina/Buenos_Aires',
-        day: '2-digit',
-        month: '2-digit',
-        year: 'numeric'
-      });
-
       const timeFmt = d.toLocaleTimeString('es-AR', {
         timeZone: 'America/Argentina/Buenos_Aires',
         hour: '2-digit',
         minute: '2-digit',
-        second: '2-digit'
+        second: '2-digit',
+        hour12: false
       });
 
       return {
         label: 'SISTEMA  (GMT-3)',
-        staticText: `SISTEMA: ${dateFmt} `,
+        staticText: 'SYS ',
         blinkText: timeFmt
       };
     }
@@ -583,35 +577,25 @@
       const sorted  = [...timestamps].sort((a,b) => a-b);
       const mtp     = sorted[Math.floor(sorted.length/2)] + 3300;
       const mtpDate = new Date(mtp * 1000);
-      const mtpDateFmt = mtpDate.toLocaleDateString('es-AR', {
-        timeZone: 'America/Argentina/Buenos_Aires',
-        day: '2-digit',
-        month: '2-digit',
-        year: 'numeric'
-      });
 
       const mtpTimeFmt = mtpDate.toLocaleTimeString('es-AR', {
         timeZone: 'America/Argentina/Buenos_Aires',
         hour: '2-digit',
         minute: '2-digit',
-        second: '2-digit'
+        second: '2-digit',
+        hour12: false
       });
 
       // Media
       const mean     = Math.round(timestamps.reduce((s,t) => s+t, 0) / timestamps.length) + 3300;
       const meanDate = new Date(mean * 1000);
-      const meanDateFmt = meanDate.toLocaleDateString('es-AR', {
-        timeZone: 'America/Argentina/Buenos_Aires',
-        day: '2-digit',
-        month: '2-digit',
-        year: 'numeric'
-      });
 
       const meanTimeFmt = meanDate.toLocaleTimeString('es-AR', {
         timeZone: 'America/Argentina/Buenos_Aires',
         hour: '2-digit',
         minute: '2-digit',
-        second: '2-digit'
+        second: '2-digit',
+        hour12: false
       });
 
       statusBar.textContent = `✓ Datos actualizados · vía ${result.method}`;
@@ -620,12 +604,12 @@
         sysCh,
         {
           label: 'MTP + 3300s  (BTC)',
-          staticText: `MTP: ${mtpDateFmt} `,
+          staticText: 'MTP ',
           blinkText: mtpTimeFmt
         },
         {
           label: 'MEDIA + 3300s (BTC)',
-          staticText: `MEDIA: ${meanDateFmt} `,
+          staticText: 'AVG ',
           blinkText: meanTimeFmt
         }
       ]);


### PR DESCRIPTION
### Motivation
- Make the LED messages much shorter so they fit within 80 columns and the full time is visible when the marquee pauses. 
- Ensure the blinking time segment is always the complete 24-hour time for consistent pause+blink behavior.

### Description
- Replaced `getSystemChannel()` to emit a short static prefix `SYS ` and a 24-hour `blinkText` using `hour12: false` in `toLocaleTimeString`.
- Updated MTP and mean time formatting in `getBlockchainTimes()` to use explicit 24-hour formatting (`hour12: false`).
- Shortened blockchain channel `staticText` values to `MTP ` and `AVG ` and kept the full 24H time in `blinkText` so each channel displays e.g. `SYS 14:32:10`, `MTP 14:21:44`, `AVG 14:25:02`.
- All changes applied to `index.html` where channels are assembled and time strings computed.

### Testing
- Ran `git diff --check` and it completed successfully.
- Ran `node --check /tmp/bitcoinclock-script.js` to validate the script syntax and it succeeded.
- Verified repository status with `git status --short` after the change.
- Attempted screenshot/headless browser capture but no browser/runtime was available in the environment, so visual verification was not performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d192757a8832dbfa70849721812aa)