### PR TITLE
Evitar saltos en actualización de canales y reducir espaciado entre caracteres LED

### DIFF
--- a/index.html
+++ b/index.html
@@ -159,6 +159,7 @@
     // ═══════════════════════════════════════════════════════════════
     // Fases: 'scroll-in' → 'pause' → 'scroll-out' → (siguiente canal)
     let channels    = [];   // array de { label, text } que se irán cargando
+    let pendingChannels = null; // nuevos canales pendientes para aplicar al terminar el ciclo completo
     let chanIdx     = 0;
     let phase       = 'idle'; // idle | scroll-in | pause | blink | scroll-out
     let colOffset   = 0;      // columna de inicio del mensaje en la pantalla
@@ -383,8 +384,20 @@
         // Salió completamente por la izquierda
         if (colOffset + msgColumns.length <= 0) {
           clearScreen();
+
           if (channels.length > 0) {
-            loadChannel(chanIdx + 1);
+            const nextIdx = chanIdx + 1;
+
+            if (nextIdx >= channels.length) {
+              if (pendingChannels) {
+                channels = pendingChannels;
+                pendingChannels = null;
+              }
+
+              loadChannel(0);
+            } else {
+              loadChannel(nextIdx);
+            }
           } else {
             phase = 'idle';
           }
@@ -474,13 +487,22 @@
       return cols;
     }
 
+    function blankColumns(n = 3) {
+      return Array.from({ length: n }, () => Array(ROWS).fill(false));
+    }
+
     function textToLED(text) {
       const out = [];
       const up  = text.toUpperCase();
+
       for (let i = 0; i < up.length; i++) {
         out.push(...charToColumns(up[i]));
-        out.push(...charToColumns(' ')); // separador entre letras
+
+        if (i < up.length - 1) {
+          out.push(...blankColumns(3));
+        }
       }
+
       return out;
     }
 
@@ -505,7 +527,7 @@
 
     refreshBtn.addEventListener('click', () => {
       statusBar.textContent = 'Actualizando datos…';
-      getBlockchainTimes();
+      getBlockchainTimes(false);
     });
 
     function adjustOff(hex) {
@@ -519,10 +541,22 @@
     // ═══════════════════════════════════════════════════════════════
     //  CARGA DE CANALES Y ARRANQUE
     // ═══════════════════════════════════════════════════════════════
-    function setChannels(data) {
-      channels = data;
-      chanIdx  = 0;
-      if (channels.length > 0) loadChannel(0);
+    function setChannels(data, options = {}) {
+      const immediate = options.immediate === true;
+
+      if (channels.length === 0 || immediate) {
+        channels = data;
+        pendingChannels = null;
+        chanIdx = 0;
+
+        if (channels.length > 0) {
+          loadChannel(0);
+        }
+
+        return;
+      }
+
+      pendingChannels = data;
     }
 
     // ─── Datos de tiempo del sistema (siempre disponibles) ────────
@@ -545,7 +579,7 @@
     }
 
     // ─── Datos de blockchain ──────────────────────────────────────
-    async function getBlockchainTimes() {
+    async function getBlockchainTimes(immediate = false) {
       const fetchers = BTC_FETCHERS;
       const methods  = ['mempool', 'blockstream', 'proxy1'];
       let result = null;
@@ -562,14 +596,14 @@
 
       if (!result) {
         statusBar.textContent = '⚠️ Sin datos de blockchain · mostrando reloj del sistema';
-        setChannels([sysCh]);
+        setChannels([sysCh], { immediate });
         return;
       }
 
       const timestamps = result.blocks.map(b => b.time).filter(t => t && !isNaN(t));
       if (timestamps.length < 11) {
         statusBar.textContent = '⚠️ Bloques insuficientes · mostrando reloj del sistema';
-        setChannels([sysCh]);
+        setChannels([sysCh], { immediate });
         return;
       }
 
@@ -612,7 +646,7 @@
           staticText: 'AVG ',
           blinkText: meanTimeFmt
         }
-      ]);
+      ], { immediate });
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -662,13 +696,13 @@
     // ═══════════════════════════════════════════════════════════════
     buildMatrix();
     requestAnimationFrame(loop);
-    getBlockchainTimes();
+    getBlockchainTimes(true);
 
     // Auto-refresh cada 60 s
     setInterval(() => {
       // Solo actualiza los datos; no interrumpe la animación actual
       // Los nuevos channels se cargan al terminar el ciclo actual
-      getBlockchainTimes();
+      getBlockchainTimes(false);
     }, 60000);
 
   </script>


### PR DESCRIPTION
### Motivation
- Evitar reinicios visuales cuando se refrescan las horas y reducir la separación entre caracteres sin cambiar la fuente 5×7 ni el diseño visual.
- Hacer que las nuevas horas se apliquen solo al completar el ciclo visual SYS → MTP → AVG para evitar saltos durante la animación.

### Description
- Añadido `blankColumns(n = 3)` y modificado `textToLED(text)` para insertar exactamente 3 columnas vacías entre caracteres y no añadir separador al final, preservando la fuente 5×7; cambio en `index.html` alrededor de la sección de fuente y conversión a columnas. 
- Implementado buffer doble con `let pendingChannels = null` y lógica en la fase `scroll-out` de `tickScroll()` para aplicar `pendingChannels` únicamente al terminar el último canal y antes de recargar el canal 0. 
- Reescrita `setChannels(data, options = {})` para soportar carga `immediate` en la inicialización o en casos que lo requieran, y para almacenar actualizaciones entrantes en `pendingChannels` sin reiniciar la animación. 
- Cambiada la firma a `async function getBlockchainTimes(immediate = false)` y propagado el flag `immediate` en las llamadas (arranque inicial `getBlockchainTimes(true)`, auto-refresh `getBlockchainTimes(false)`, botón manual `getBlockchainTimes(false)` y en los casos de error `setChannels([sysCh], { immediate })`).

### Testing
- Se ejecutaron comprobaciones de contenido con `python3` que verifican presencia de `blankColumns`, `pendingChannels`, `setChannels(..., options)` y las firmas/llamadas nuevas, y dichas aserciones pasaron correctamente. 
- Se validó la sintaxis del bloque `<script>` con `node -e` creando y evaluando la función y la comprobación devolvió `JS syntax OK`.
- Se ejecutó `git diff --check` para detectar problemas de formato y no se encontraron errores.
- Intento de prueba visual automática con Playwright falló por ausencia del paquete/navegador en el entorno, por lo que no se generaron capturas de pantalla automáticas aquí.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d1be493e0832db6434bb830a1f87d)