### PR TITLE
Reducir espaciado entre caracteres del texto LED

### DIFF
--- a/index.html
+++ b/index.html
@@ -499,7 +499,7 @@
         out.push(...charToColumns(up[i]));
 
         if (i < up.length - 1) {
-          out.push(...blankColumns(3));
+          out.push(...blankColumns(1));
         }
       }
 


### PR DESCRIPTION
### Motivation
- El texto completo (por ejemplo `SYS 16:35:14`) se truncaba en el ancho de 80 columnas al usar la fuente 5×7 con separadores de 3 columnas, por lo que es necesario reducir el espacio entre caracteres para que quepa.

### Description
- Se redujo el espaciado intercarácter en la función `textToLED` de `index.html` cambiando `out.push(...blankColumns(3));` por `out.push(...blankColumns(1));` para usar una columna vacía entre caracteres en lugar de tres.

### Testing
- Se ejecutó un script Python que calcula el ancho de `SYS 16:35:14` con separador de 1 columna y la aserción pasó (resultado: 71 columnas).
- Se ejecutó `git diff --check` y no reportó errores de espacio en blanco, por lo que el parche está limpio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a456cebd524832d857240a920193947)